### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/LDX/TouchHome/Main.php
+++ b/src/LDX/TouchHome/Main.php
@@ -16,11 +16,8 @@ class Main extends PluginBase implements Listener {
   public function onEnable() {
     $this->getLogger()->info(TextFormat::YELLOW . "Enabling TouchHome...");
     $this->getServer()->getPluginManager()->registerEvents($this,$this);
-    if(!file_exists($this->getDataFolder() . "config.yml")) {
-      @mkdir($this->getDataFolder());
-      file_put_contents($this->getDataFolder() . "config.yml",$this->getResource("config.yml"));
-    }
-    $c = yaml_parse(file_get_contents($this->getDataFolder() . "config.yml"));
+    $this->saveDefaultConfig();
+    $c = $this->getConfig()->getAll();
     $this->item = $c["item"];
   }
   public function onCommand(CommandSender $p,Command $cmd,$label,array $args) {


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:
- `Plugin->getResource()` without `fclose()` calls later
- Not needed `Plugin->getResource()` calls
- `fopen()` calls without `fclose()`
- `popen()` calls without `pclose()`
